### PR TITLE
Speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# VS code
+.vscode
+
+# venv
+venv

--- a/p_entropy.py
+++ b/p_entropy.py
@@ -1,9 +1,7 @@
 ''' This module has essential functions supporting
 fast and effective computation of permutation entropy and
 its different variations.'''
-import itertools
 import numpy as np
-import pandas as pd
 
 
 def s_entropy(freq_list):
@@ -36,7 +34,7 @@ def ordinal_patterns(ts, embdim, embdelay):
     counts = np.zeros(np.math.factorial(m))
     for i in range(counts.shape[0]):
         counts[i] = (idx == i).sum()
-    return list(counts[counts != 0])
+    return list(counts[counts != 0].astype(int))
 
 def _hash(x):
     m, n = x.shape
@@ -70,22 +68,19 @@ def complexity(op):
     return(Comp_JS)
 
 def weighted_ordinal_patterns(ts, embdim, embdelay):
-    time_series = ts
-    possible_permutations = list(itertools.permutations(range(embdim)))
-    temp_list = list()
-    wop = list()
-    for i in range(len(time_series) - embdelay * (embdim - 1)):
-        Xi = time_series[i:(embdim+i)]
-        Xn = time_series[(i+embdim-1): (i+embdim+embdim-1)]
-        Xi_mean = np.mean(Xi)
-        Xi_var = (Xi-Xi_mean)**2
-        weight = np.mean(Xi_var)
-        sorted_index_array = list(np.argsort(Xi))
-        temp_list.append([''.join(map(str, sorted_index_array)), weight])
-    result = pd.DataFrame(temp_list,columns=['pattern','weights'])
-    freqlst = dict(result['pattern'].value_counts())
-    for pat in (result['pattern'].unique()):
-        wop.append(np.sum(result.loc[result['pattern']==pat,'weights'].values))
-    return(wop)
+    m, t = embdim, embdelay
+    x = ts if isinstance(ts, np.ndarray) else np.array(ts) 
 
+    tmp = np.zeros((x.shape[0], m))
+    for i in range(m):
+        tmp[:, i] = np.roll(x, i*t)
+    partition = tmp[(t*m-1):, :] 
+    xm = np.mean(partition, axis=1)
+    weight = np.mean((partition - xm[:, None])**2, axis=1)
+    permutation = np.argsort(partition)
+    idx = _hash(permutation)
+    counts = np.zeros(np.math.factorial(m))
+    for i in range(counts.shape[0]):
+        counts[i] = sum(weight[i == idx])
 
+    return list(counts[counts != 0]) 


### PR DESCRIPTION
Hello, first of all thanks for doing this module.

I speed up the way of how the ordinal patterns are calculated. I send you a small script with some benchmarks that I did.

```python
import numpy as np
import p_entropy
from time import time

np.random.seed(0)
x = np.random.rand(1000000)

t0 = time()
#pat = p_entropy.weighted_ordinal_patterns(x, 3, 1)
pat = p_entropy.ordinal_patterns(x, 3, 1)
ent = p_entropy.s_entropy(pat)
t1 = time()

print(f"ent = {ent} @ {t1-t0} seg.")

# Ordinal patterns
# ent = -12023726.254187914 @ 6.492926120758057 seg.
# ent = -12023726.254187914 @ 0.11095786094665527 seg.

# Weighted ordinal patterns
# ent = -507757.0070456004 @ 33.776389837265015 seg.
# ent = -507757.0070456012 @ 0.26566362380981445 seg.

```
I hope that what has been done is useful.